### PR TITLE
Switch to supported version of Guzzle

### DIFF
--- a/src/Fs.php
+++ b/src/Fs.php
@@ -8,7 +8,7 @@
 namespace vaersaagod\dospaces;
 
 use Aws\Credentials\Credentials;
-use Aws\Handler\GuzzleV6\GuzzleHandler;
+use Aws\Handler\Guzzle\GuzzleHandler;
 use Craft;
 use craft\behaviors\EnvAttributeParserBehavior;
 use craft\flysystem\base\FlysystemFs;


### PR DESCRIPTION
We noticed the same error as reported in #30. 

This change switches to the version of Guzzle supported by the AWS SDK. 